### PR TITLE
fix(intermediate/style): remove backquote

### DIFF
--- a/docs/fr/workshops/intermediate/style.md
+++ b/docs/fr/workshops/intermediate/style.md
@@ -121,7 +121,7 @@ module.exports = {
       {
         test: /\.sass$/,
         use: [
-          { loader: `MiniCssExtractPlugin.loader` },
+          { loader: MiniCssExtractPlugin.loader },
           "css-loader",
           "sass-loader"
         ]


### PR DESCRIPTION
The use of backquotes no longer works with the current version :
https://github.com/webpack-contrib/mini-css-extract-plugin

The following code causes the error
```
{
        test: /\.sass$/,
        use: [
          { loader: `MiniCssExtractPlugin.loader` },
          "css-loader",
          "sass-loader"
        ]
      }
```

ERROR in ./src/main.js
Module not found: Error: Can't resolve 'MiniCssExtractPlugin.loader' in '/Users/agory/Documents/tuto/webpack-workshop/packages/intermediate/style'
 @ ./src/main.js 3:0-25