### PR TITLE
fix(intermediate/reduce):  update arg and import

### DIFF
--- a/packages/intermediate/reduce-bundle-size/webpack.config.js
+++ b/packages/intermediate/reduce-bundle-size/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 
 module.exports = {
   entry: "./src/main.js", // The source module of our dependency graph

--- a/packages/intermediate/reduce-bundle-size/webpack.config.js
+++ b/packages/intermediate/reduce-bundle-size/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const CleanWebpackPlugin = require("clean-webpack-plugin");
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = {
   entry: "./src/main.js", // The source module of our dependency graph
@@ -38,7 +38,7 @@ module.exports = {
     }
   },
   plugins: [
-    new CleanWebpackPlugin("dist"),
+    new CleanWebpackPlugin(),
     new HtmlWebpackPlugin({
       template: "./src/index.html"
     })


### PR DESCRIPTION
The latest version of clean-webpack-plugin has changed its import method and uses by default `output.path`.

The tutorial currently gives the following error:
/Users/agory/Documents/tuto/webpack-workshop/packages/intermediate/reduce-bundle-size/webpack.config.js:42
    new CleanWebpackPlugin("dist"),
    ^

TypeError: CleanWebpackPlugin is not a constructor
    at Object.<anonymous> (.../webpack-workshop/packages/intermediate/reduce-bundle-size/webpack.config.js:42:5)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at WEBPACK_OPTIONS (.../webpack-workshop/node_modules/webpack-cli/bin/utils/convert-argv.js:114:13)
    at requireConfig (.../webpack-workshop/node_modules/webpack-cli/bin/utils/convert-argv.js:116:6)