### PR TITLE
fix typos and update link

### DIFF
--- a/docs/workshops/intermediate/dev.md
+++ b/docs/workshops/intermediate/dev.md
@@ -20,7 +20,7 @@ For this two painful new problems, webpack offers solutions.
 
 ## Source maps
 
-When your generated JS code is not humanly readable because it has been minified or bundle you need [source maps](https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map).
+When your generated JS code is not humanly readable because it has been minified or bundled you need [source maps](https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map).
 In this exercise, the app is displaying pokemons.
 
 Run:

--- a/docs/workshops/intermediate/dev.md
+++ b/docs/workshops/intermediate/dev.md
@@ -33,7 +33,7 @@ Try to open the generated bundle in the browser devtools, this should be very co
 
 To generate your source maps:
 
-- toggle development [mode](https://webpack.js.org/concepts/mode) of your build
+- toggle development [mode](https://webpack.js.org/concepts/#mode) of your build
 - define devtools to `inline-source-map`
 
 :::tip


### PR DESCRIPTION
⚠️ There was a diff between french and english intermediate/dev workshop links to mode webpack documentation.
Which one do you prefer to keep ? (configuration or concepts)
